### PR TITLE
Use cmake configured completion file

### DIFF
--- a/bionic/debian/control
+++ b/bionic/debian/control
@@ -4,7 +4,6 @@ Maintainer: Jose Luis Rivero <jrivero@osrfoundation.org>
 Section: science
 Priority: optional
 Build-Depends: debhelper (>= 9~),
-               dh-exec,
                gem2deb,
                cmake,
                pkg-config

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -4,7 +4,6 @@ Section: science
 Priority: optional
 Build-Depends: debhelper (>= 11),
                cmake,
-               dh-exec,
                gem2deb,
                libbackward-cpp-dev,
                ruby,

--- a/ubuntu/debian/ignition-tools.install
+++ b/ubuntu/debian/ignition-tools.install
@@ -1,4 +1,3 @@
-#!/usr/bin/dh-exec
 usr/bin/*
 usr/lib/*/libignition-tools-backward.so
-etc/ign.bash_completion.sh => /usr/share/bash-completion/completions/ign
+usr/share/*


### PR DESCRIPTION
We were using the `ign.bash_completion.sh` file from the source, not after it was configured by cmake. In https://github.com/gazebosim/gz-tools/pull/103, I needed to use a cmake configured file in order to source `gz1.completion` from wherever it's installed. This is so that the bash completion files for other ign/gz libraries can be sourced automatically. 

Also in that PR, I'm using cmake to install the `etc/ign.bash_completion.sh` to `/usr/share/bash-completion/completions/ign`, so the `ignition-tools.install` file can be simplified (no need for renames). It also makes it possible for users to build from `ign-tools` from source and still get tab completion.

In addition, this PR installs `/usr/share/gz/gz1.completion`, which wasn't being installed before.

The resulting deb file has the following contents

```
drwxr-xr-x root/root         0 2021-10-27 11:04 ./
drwxr-xr-x root/root         0 2021-10-27 11:04 ./usr/
drwxr-xr-x root/root         0 2021-10-27 11:04 ./usr/bin/
-rwxr-xr-x root/root      9256 2021-10-27 11:04 ./usr/bin/ign
drwxr-xr-x root/root         0 2021-10-27 11:04 ./usr/lib/
drwxr-xr-x root/root         0 2021-10-27 11:04 ./usr/lib/x86_64-linux-gnu/
-rw-r--r-- root/root     52040 2021-10-27 11:04 ./usr/lib/x86_64-linux-gnu/libignition-tools-backward.so
drwxr-xr-x root/root         0 2021-10-27 11:04 ./usr/share/
drwxr-xr-x root/root         0 2021-10-27 11:04 ./usr/share/bash-completion/
drwxr-xr-x root/root         0 2021-10-27 11:04 ./usr/share/bash-completion/completions/
-rw-r--r-- root/root      1981 2021-10-27 11:04 ./usr/share/bash-completion/completions/ign
drwxr-xr-x root/root         0 2021-10-27 11:04 ./usr/share/doc/
drwxr-xr-x root/root         0 2021-10-27 11:04 ./usr/share/doc/ignition-tools/
-rw-r--r-- root/root       396 2021-10-27 11:04 ./usr/share/doc/ignition-tools/changelog.Debian.gz
-rw-r--r-- root/root       328 2021-10-26 11:48 ./usr/share/doc/ignition-tools/copyright
drwxr-xr-x root/root         0 2021-10-27 11:04 ./usr/share/gz/
-rw-r--r-- root/root      1123 2021-10-27 11:04 ./usr/share/gz/gz1.completion
```
See https://github.com/gazebosim/gz-tools/pull/103 for quick instructions for building the deb file locally.

**Note**
Not sure if this has been addressed before, but AFAIK, installing to `/usr/share/bash-completion/completions/ign` will prevent side-by-side installation of ign-tools. I guess for the near term it won't be a problem because `ign-tools2` would be using `gz` instead of `ign`, but could be a problem if we have `ign-tools3` at some point.
